### PR TITLE
Status bug when orders go through Fulfillment twice

### DIFF
--- a/src/Message/Mothership/Ecommerce/Controller/Fulfillment/Process.php
+++ b/src/Message/Mothership/Ecommerce/Controller/Fulfillment/Process.php
@@ -520,7 +520,7 @@ class Process extends Controller
 	protected function _getOrderItems($orderID, $status = null)
 	{
 		$order = $this->_getOrder($orderID);
-		$items = ($status) ? $order->items->getByCurrentStatusCode($status) : $order->items->all();
+		$items = (null !== $status) ? $order->items->getByCurrentStatusCode($status) : $order->items->all();
 
 		return $items;
 


### PR DESCRIPTION
# Steps to reproduce
- Create an order
- Fully dispatch it
- As the customer, raise an exchange for one of the items
- Fully process and accept the exchange and send the replacement item to Fulfillment
# Issue description

When you "print" the order again in "new", it sets the status of `100 (Printed)` for all items in the order. This allows the items to all be re-dispatched in Fulfillment again. Bad times!
# Intended behaviour

When marking orders as "printed", it should only set this status against items that have the current status of `0 (Awaiting Dispatch)`.
