### PR TITLE
Checkout: Delivery countries should be filterable

### DIFF
--- a/src/Message/Mothership/Ecommerce/Form/UserDetails.php
+++ b/src/Message/Mothership/Ecommerce/Form/UserDetails.php
@@ -68,8 +68,12 @@ class UserDetails extends Handler
 			'choices' => $this->_container['state.list']->all(),
 			'empty_value' => 'Please select...'
 		))->val()->optional();
+
+
+		$event = $this->_container['country.event'];
+
 		$this->add('country_id','choice','Country', array(
-			'choices' => $this->_container['country.list']->all(),
+			'choices' => $this->_container['event.dispatcher']->dispatch('country.delivery', $event)->getCountries(),
 			'empty_value' => 'Please select...'
 		));
 


### PR DESCRIPTION
We could use events like so:

``` php
$event = $this->_container['country.event'];

$this->add('country_id','choice','Country', array(
    'choices' => $this->_container['event.dispatcher']->dispatch(
        'country.delivery', $event)->getCountries(),
    'empty_value' => 'Please select...'
));
```

and

``` php
// listener
$event->setCountries(array_intersect_key($event->getCountries(), array_flip(
    array('GB', 'US', 'CA')
)));
```
