### PR TITLE
Allow re-printing of dispatch labels

### DIFF
--- a/src/Message/Mothership/Ecommerce/File/PackingSlip.php
+++ b/src/Message/Mothership/Ecommerce/File/PackingSlip.php
@@ -143,7 +143,7 @@ class PackingSlip implements ContainerAwareInterface
 		$handler = $manager::getHandler('cog');
 		$path = $handler->getLocalPath($path);
 
-		$this->_container['filesystem.conversion.pdf']->setHtml($contents)->save($path);
+		$this->_container['filesystem']->dumpFile($path, $contents);
 
 		return true;
 	}
@@ -157,7 +157,7 @@ class PackingSlip implements ContainerAwareInterface
 	 */
 	protected function _getPath($filename)
 	{
-		return $this->_fileDestination . '/' . $filename . '.pdf';
+		return $this->_fileDestination . '/' . $filename . '.html';
 	}
 
 	/**

--- a/src/Message/Mothership/Ecommerce/File/PackingSlip.php
+++ b/src/Message/Mothership/Ecommerce/File/PackingSlip.php
@@ -143,7 +143,7 @@ class PackingSlip implements ContainerAwareInterface
 		$handler = $manager::getHandler('cog');
 		$path = $handler->getLocalPath($path);
 
-		$this->_container['filesystem']->dumpFile($path, $contents);
+		$this->_container['filesystem.conversion.pdf']->setHtml($contents)->save($path);
 
 		return true;
 	}
@@ -157,7 +157,7 @@ class PackingSlip implements ContainerAwareInterface
 	 */
 	protected function _getPath($filename)
 	{
-		return $this->_fileDestination . '/' . $filename . '.html';
+		return $this->_fileDestination . '/' . $filename . '.pdf';
 	}
 
 	/**


### PR DESCRIPTION
This is going to be tricky.

- For `.txt` labels, we need to use `jZebraControl` to print the buffer in Javascript
- Otherwise for PNG and PDF labels we just link to the file / render them in a new window

This should probably happen in the `Commerce` module, not here. But that will require moving the jZebra functionality. (see #58) Hmmm!!