### PR TITLE
Filtering methods for removing non web orders and dispatches

### DIFF
--- a/src/Message/Mothership/Ecommerce/Controller/Fulfillment/Fulfillment.php
+++ b/src/Message/Mothership/Ecommerce/Controller/Fulfillment/Fulfillment.php
@@ -294,6 +294,13 @@ class Fulfillment extends Controller
 		);
 	}
 
+	/**
+	 * Filter out any orders that do not have a type of 'web'
+	 * @todo load only the correct orders in the first place
+	 *
+	 * @param $orders
+	 * @return array
+	 */
 	protected function _filterWebOrders($orders)
 	{
 		$webOrders = array();
@@ -307,6 +314,13 @@ class Fulfillment extends Controller
 		return $webOrders;
 	}
 
+	/**
+	 * Filter out any dispatches that do not have an order type of 'web'.
+	 * @todo load only the correct dispatches in the first place
+	 *
+	 * @param $dispatches
+	 * @return array
+	 */
 	protected function _filterWebDispatches($dispatches)
 	{
 		$webDispatches = array();


### PR DESCRIPTION
Ideally you would use the loader to load orders by type and status, and I initially tried to see what I could do the the commerce module, but there didn't appear to be any good, simple way to fix this without having to rewrite a lot of stuff. Looping through all the loaded orders and dispatches feels a little inefficient so I wouldn't say this is a permanent solution, but at the moment it feels like the simplest and safest solution
