### PR TITLE
Fixed payment error logging error

### DIFF
--- a/src/Message/Mothership/Ecommerce/Bootstrap/Services.php
+++ b/src/Message/Mothership/Ecommerce/Bootstrap/Services.php
@@ -41,7 +41,7 @@ class Services implements ServicesInterface
 		$services['log.payments'] = $services->share(function($c) {
 			$logger = new \Monolog\Logger('payments');
 
-			if (in_array($services['env'], array('live', 'staging'))) {
+			if (in_array($c['env'], array('live', 'staging'))) {
 				$logger->pushHandler(
 					new \Monolog\Handler\HipChatHandler(
 						'fa33f6b754f4a4663cc3d7efd025bb',

--- a/src/Message/Mothership/Ecommerce/Controller/Checkout/Payment.php
+++ b/src/Message/Mothership/Ecommerce/Controller/Checkout/Payment.php
@@ -97,10 +97,10 @@ class Payment extends Controller
 			$this->addFlash('error', 'Couldn\'t connect to payment gateway');
 
 			// Log the error
-			$this->get('log.payments')->error(sprintf(
-				"An error occured when a customer tried to make a payment with response: %s",
-				print_r($response, true)
-			));
+			$this->get('log.payments')->error(
+				"An error occured when a customer tried to make a payment.",
+				$response->getData()
+			);
 		}
 
 		return $this->redirectToRoute('ms.ecom.checkout.confirm');


### PR DESCRIPTION
Was referencing `$services` inside a closure when it should have been referencing `$c`.

Also cleaned up output from the payment error log to hipchat to use the `$context` parameter instead of a single formatted line.
