### PR TITLE
Fixed status createdBy user loading in fulfillment

### DIFF
--- a/src/Message/Mothership/Ecommerce/Controller/Fulfillment/Fulfillment.php
+++ b/src/Message/Mothership/Ecommerce/Controller/Fulfillment/Fulfillment.php
@@ -286,7 +286,13 @@ class Fulfillment extends Controller
 			foreach ($history as $status) {
 				if ($status->code === $statusCode) {
 					$itemsWithStatus++;
-					$users = $this->_addUserToStatus($users, $status);
+
+					$id = $status->authorship->createdBy();
+					if (! isset($users[$id])) {
+						if ($user = $this->get('user.loader')->getByID($id)) {
+							$users[$id] = $user->getInitials();
+						}
+					}
 				}
 			}
 		}
@@ -338,35 +344,6 @@ class Fulfillment extends Controller
 		}
 
 		return $webDispatches;
-	}
-
-	protected function _getUserList($items)
-	{
-		$users = array();
-		foreach ($items as $item) {
-			$users = $this->_addUserToStatus($users, $item);
-		}
-
-		return implode(', ', $users);
-	}
-
-
-	protected function _addUserToStatus(array $users, $status)
-	{
-		$id = $status->authorship->createdBy();
-		if (! isset($users[$id])) {
-			$user = $this->_getUser($id);
-			if ($user) {
-				$users[$id] = $user->getInitials();
-			}
-		}
-
-		return $users;
-	}
-
-	protected function _getUser($id)
-	{
-		return $this->get('user.loader')->getByID($id);
 	}
 
 }


### PR DESCRIPTION
https://trello.com/c/wv9B68dM

> FIX - ORDER - Items in Fulfilment for orders, multiple initials are being assigned to each stage of it. It should just be one person per step please fix.

The `_addUserToStatus` method was just pulling out all the history for the item and getting all the users who had at any point modified it at any time. This fix makes it only pick the user associated with the particular status.
### Todo
- [x] There seems to be some superfluous code which could be removed in related methods.
