### PR TITLE
Gift vouchers not applied to payment gateway request

### DIFF
--- a/src/Message/Mothership/Ecommerce/Controller/Checkout/Payment.php
+++ b/src/Message/Mothership/Ecommerce/Controller/Checkout/Payment.php
@@ -92,7 +92,7 @@ class Payment extends Controller
 		$gateway->setBillingAddress($billing);
 		$gateway->setDeliveryAddress($delivery);
 		$gateway->setOrder($order);
-		$gateway->setPaymentAmount($order->totalGross, $order->currencyID);
+		$gateway->setPaymentAmount($order->getAmountDue(), $order->currencyID);
 		$gateway->setRedirectUrl($this->getUrl().'/checkout/payment/response');
 
 		$response = $gateway->send();


### PR DESCRIPTION
Previously this would send the gross amount on the order which ignored any other types of payments already made (i.e. gift vouchers).
