### PR TITLE
Removed account route in ecommerce

### DIFF
--- a/src/Bootstrap/Routes.php
+++ b/src/Bootstrap/Routes.php
@@ -123,7 +123,6 @@ class Routes implements RoutesInterface
 			->setMethod('POST');
 
 		$router['ms.ecom.account']->setPrefix('/account');
-		$router['ms.ecom.account']->add('ms.ecom.account', '/', 'Message:Mothership:Ecommerce::Controller:Account:Account#index');
 		$router['ms.ecom.account']->add('ms.ecom.order.listing', '/orders', 'Message:Mothership:Ecommerce::Controller:Account:Account#orderListing');
 		$router['ms.ecom.account']->add('ms.ecom.order.detail', '/orders/view/{orderID}', 'Message:Mothership:Ecommerce::Controller:Account:Account#orderDetail')
 			->setMethod('GET');


### PR DESCRIPTION
#### What does this do?

Removed account route, because for some reason, when on union's epos branch, the actual account-route did not override this one (although it does on master...).
#### How should this be manually tested?

Check out this branch and try to go to `/account` to see whether you get to the right controller now!
#### Related PRs / Issues / Resources?

Original issue: https://github.com/messagedigital/union-music-store/issues/123
More on this: https://github.com/messagedigital/cog-mothership-ecommerce/issues/199
#### Anything else to add? (Screenshots, background context, etc)
