### PR TITLE
Change basket blob to longblob

### DIFF
--- a/resources/migrations/_1400575591_BasketBlobToLongBlob.php
+++ b/resources/migrations/_1400575591_BasketBlobToLongBlob.php
@@ -1,0 +1,16 @@
+<?php
+
+use Message\Cog\Migration\Adapter\MySQL\Migration;
+
+class _1400575591_BasketBlobToLongBlob extends Migration
+{
+	public function up()
+	{
+		$this->run("ALTER TABLE basket MODIFY contents LONGBLOB;");
+	}
+
+	public function down()
+	{
+		$this->run("ALTER TABLE basket MODIFY contents BLOB;");
+	}
+}


### PR DESCRIPTION
Simple migration to change the data type for the basket contents field in the database to be a `LONGBLOB` rather than a `BLOB`
