### PR TITLE
Add missing class to automatic dispatch link

### DIFF
--- a/resources/view/fulfillment/process/post.html.twig
+++ b/resources/view/fulfillment/process/post.html.twig
@@ -31,7 +31,7 @@
 				{{ form_start(form) }}
 					{{ form_row(form.deliveryID) }}
 					{% if dispatch.method.allowAutomaticPostage %}
-						<a href="{{ url('ms.ecom.fulfillment.process.post.auto', {orderID: dispatch.order.id, dispatchID: dispatch.id}) }}" class="button small submit">Postage this package automatically</a>
+						<a href="{{ url('ms.ecom.fulfillment.process.post.auto', {orderID: dispatch.order.id, dispatchID: dispatch.id}) }}" class="button small submit dispatch-automatically">Postage this package automatically</a>
 					{% endif %}
 					<button type="submit" class="button small save" id="save-content">{{ action }}</button>
 				{{form_end(form)  }}


### PR DESCRIPTION
#### What does this do?

Adds back a class that was removed at some point, breaking the Ajax hook on automatic dispatch.
#### How should this be manually tested?

Use the automatic dispatch link on Uniform Wares without this branch, it should just redirect you to a page of JSON. Using this branch, you shouldn't get that same result. You'll likely get a JS error because the printer can't be found, but in the Network tab you should see that the request happened as Ajax.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)

Patrick raised this with me on the phone.

**DO NOT MERGE THIS PR! It must be merged by HubFlow**
