### PR TITLE
use show actual price on confirmation page

### DIFF
--- a/resources/view/checkout/stage-4-success.html.twig
+++ b/resources/view/checkout/stage-4-success.html.twig
@@ -88,7 +88,7 @@
 								{{ getResizedImage(item.first.product.getUnitImage(item.first.unit, 'default'), 80, 80) }}
 								{{ item.first.productName }}, {{ item.first.options }}</td>
 							<td class="quantity">{{ item.quantity }}
-							<td class="price">{{ item.basePrice|price }}</td>
+							<td class="price">{{ item.first.basePrice|price }}</td>
 						</tr>
 					{% endfor %}
 				</tbody>


### PR DESCRIPTION
#### What does this do?

Fixes he price on the Confirmation Page
#### How should this be manually tested?

Go through the checkout stages on Union (as it uses the default checkout) and check the price is correct
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
