### PR TITLE
Make address changing more watertight

### DIFF
--- a/src/Controller/Checkout/Confirm.php
+++ b/src/Controller/Checkout/Confirm.php
@@ -5,8 +5,7 @@ namespace Message\Mothership\Ecommerce\Controller\Checkout;
 use Message\Mothership\Commerce\Order\Entity\Note\Note;
 use Message\Mothership\Ecommerce\Form\UserDetails;
 use Message\Cog\Controller\Controller;
-use Message\User\User;
-use Message\User\AnonymousUser;
+use Message\Mothership\Commerce\Address\Address;
 
 /**
  * Class Checkout/Confirm
@@ -17,15 +16,19 @@ class Confirm extends Controller
 
 	public function index()
 	{
+		$order = $this->get('basket')->getOrder();
+
+		if (!$order->getAddress(Address::DELIVERY) || !$order->getAddress(Address::BILLING)) {
+			return $this->redirectToRoute('ms.ecom.checkout');
+		}
+
 		// Get the delivery form, before checking for the shipping method name
 		// otherwise this might not be set yet when there is only one method
 		// available for the order.
 		$deliveryForm = $this->deliveryMethodForm();
 
-		$shippingName = $this->get('basket')->getOrder()->shippingName;
+		$shippingName = $order->shippingName;
 		$shippingDisplayName = $shippingName ? $this->get('shipping.methods')->get($shippingName)->getDisplayName() : '';
-
-		$order = $this->get('basket')->getOrder();
 
 		return $this->render('Message:Mothership:Ecommerce::checkout:stage-2-confirm', array(
 			'continueForm'           => $this->continueForm($order),

--- a/src/Controller/Checkout/Confirm.php
+++ b/src/Controller/Checkout/Confirm.php
@@ -22,13 +22,15 @@ class Confirm extends Controller
 			return $this->redirectToRoute('ms.ecom.checkout');
 		}
 
-		// Get the delivery form, before checking for the shipping method name
-		// otherwise this might not be set yet when there is only one method
-		// available for the order.
+		$shippingMethod = $this->get('shipping.methods')->get($order->shippingName);
+
+		if (!$shippingMethod->isAvailable($order)) {
+			$order->shippingName = null;
+		}
+
 		$deliveryForm = $this->deliveryMethodForm();
 
-		$shippingName = $order->shippingName;
-		$shippingDisplayName = $shippingName ? $this->get('shipping.methods')->get($shippingName)->getDisplayName() : '';
+		$shippingDisplayName = $order->shippingName ? $shippingMethod->getDisplayName() : '';
 
 		return $this->render('Message:Mothership:Ecommerce::checkout:stage-2-confirm', array(
 			'continueForm'           => $this->continueForm($order),

--- a/src/Controller/Checkout/Confirm.php
+++ b/src/Controller/Checkout/Confirm.php
@@ -22,15 +22,15 @@ class Confirm extends Controller
 			return $this->redirectToRoute('ms.ecom.checkout');
 		}
 
-		$shippingMethod = $this->get('shipping.methods')->get($order->shippingName);
-
-		if (!$shippingMethod->isAvailable($order)) {
+		if ($order->shippingName && !$this->get('shipping.methods')->get($order->shippingName)->isAvailable($order)) {
 			$order->shippingName = null;
 		}
 
 		$deliveryForm = $this->deliveryMethodForm();
 
-		$shippingDisplayName = $order->shippingName ? $shippingMethod->getDisplayName() : '';
+		$shippingDisplayName = $order->shippingName ?
+			$this->get('shipping.methods')->get($order->shippingName)->getDisplayName() :
+			'';
 
 		return $this->render('Message:Mothership:Ecommerce::checkout:stage-2-confirm', array(
 			'continueForm'           => $this->continueForm($order),

--- a/src/EventListener/OrderListener.php
+++ b/src/EventListener/OrderListener.php
@@ -53,8 +53,6 @@ class OrderListener extends BaseListener implements SubscriberInterface
 		$redirectEvent = new Page\Event\SetResponseForRenderEvent($page, $page->getContent());
 		$redirectEvent->setResponse(new RedirectResponse($page->slug));
 
-		$this->get('http.session')->getFlashBag()->add('error', $this->get('translator')->trans('ms.ecom.error.basket'));
-
 		$this->get('event.dispatcher')->dispatch(Page\Event\Event::RENDER_SET_RESPONSE, $redirectEvent);
 	}
 }

--- a/src/EventListener/OrderListener.php
+++ b/src/EventListener/OrderListener.php
@@ -5,6 +5,8 @@ namespace Message\Mothership\Ecommerce\EventListener;
 use Message\Cog\Event\SubscriberInterface;
 use Message\Cog\Event\EventListener as BaseListener;
 use Message\Mothership\Commerce\Order;
+use Message\Mothership\CMS\Page;
+use Message\Cog\HTTP\RedirectResponse;
 
 /**
  * Order event listener.
@@ -19,9 +21,12 @@ class OrderListener extends BaseListener implements SubscriberInterface
 	static public function getSubscribedEvents()
 	{
 		return array(
-			Order\Events::CREATE_COMPLETE => array(
-				array('sendOrderConfirmationMail'),
-			)
+			Order\Events::CREATE_COMPLETE => [
+				['sendOrderConfirmationMail'],
+			],
+			Order\Events::UPDATE_FAILED => [
+				['redirectToHome']
+			],
 		);
 	}
 
@@ -39,5 +44,17 @@ class OrderListener extends BaseListener implements SubscriberInterface
 
 			$this->get('mail.dispatcher')->send($factory->getMessage());
 		}
+	}
+
+	public function redirectToHome(Order\Event\UpdateFailedEvent $event)
+	{
+		$page = $this->get('cms.page.loader')->getHomepage();
+
+		$redirectEvent = new Page\Event\SetResponseForRenderEvent($page, $page->getContent());
+		$redirectEvent->setResponse(new RedirectResponse($page->slug));
+
+		$this->get('http.session')->getFlashBag()->add('error', $this->get('translator')->trans('ms.ecom.error.basket'));
+
+		$this->get('event.dispatcher')->dispatch(Page\Event\Event::RENDER_SET_RESPONSE, $redirectEvent);
 	}
 }

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -68,5 +68,3 @@ ms.ecom:
         shop: Use shop page
     pages:
       published: '{0}%count% pages published|{1}%count% page published'
-  error:
-    basket: Could not update basket

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -68,3 +68,5 @@ ms.ecom:
         shop: Use shop page
     pages:
       published: '{0}%count% pages published|{1}%count% page published'
+  error:
+    basket: Could not update basket


### PR DESCRIPTION
Relies on https://github.com/mothership-ec/cog-mothership-commerce/pull/437

This PR:

+ Listens for `UpdateFailedEvent` and redirects users back to the home page
+ Redirects users to the first stage of checkout if addresses are missing on their order at the 'confirm' stage
+ Fixes issue where users could change their delivery address and not have the shipping method updated