### PR TITLE
Check if user exists before registration

### DIFF
--- a/src/Controller/Checkout/Details.php
+++ b/src/Controller/Checkout/Details.php
@@ -68,7 +68,7 @@ class Details extends Controller
 
 			$this->get('basket')->setEntities('addresses', $addresses);
 
-			return $this->redirectToRoute('ms.ecom.checkout.confirm');
+			return $this->redirectToRoute('ms.ecom.checkout.details.addresses');
 		}
 
 		return $this->render('Message:Mothership:Ecommerce::checkout:stage-1c-register', array(

--- a/src/Controller/Checkout/Details.php
+++ b/src/Controller/Checkout/Details.php
@@ -29,6 +29,16 @@ class Details extends Controller
 		if ($form->isValid()) {
 			$data = $form->getData();
 
+			if ($this->get('user.loader')->getByEmail($data['email'])) {
+				$this->addFlash('error', $this->trans('ms.ecom.user.register.email-in-use', [
+					'%forgottenLink%' => $this->generateUrl('ms.user.password.request'),
+				]));
+
+				return $this->render('Message:Mothership:Ecommerce::checkout:stage-1c-register', array(
+					'form' => $form,
+				));
+			}
+
 			// Build and create the user
 			$user = $this->get('user');
 			$user->forename = $data['addresses']['billing']->forename;
@@ -37,15 +47,7 @@ class Details extends Controller
 			$user->email    = $data['email'];
 			$user->title    = $data['addresses']['billing']->title;
 
-			try {
-				$user = $this->get('user.create')->save($user);
-			} catch (\Exception $e) {
-				$this->addFlash('error', 'Email address is already in use');
-
-				return $this->render('Message:Mothership:Ecommerce::checkout:stage-1c-register', array(
-					'form' => $form,
-				));
-			}
+			$user = $this->get('user.create')->save($user);
 
 			// Set the user session
 			$this->get('http.session')->set($this->get('cfg')->user->sessionName, $user);

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -54,6 +54,8 @@ ms.ecom:
       state-required: This value is required for %s addresses.
       country: Country
       deliver-different: Deliver to different address
+    register:
+      email-in-use: This email address in already in use, have you <a href="%forgottenLink%">forgotten your password</a>?
   product:
     upload:
       form:


### PR DESCRIPTION
Previously registration via the checkout was just catching exceptions and assuming it was because the password was in use, which is a rubbish way to validate the form. Now it no longer catches exceptions and just has a check to see if the user already exists before processing the form.