### PR TITLE
Page unit records and optimise sale filter

### DIFF
--- a/resources/migrations/_1440409241_PageUnitRecord.php
+++ b/resources/migrations/_1440409241_PageUnitRecord.php
@@ -1,0 +1,27 @@
+<?php
+
+use Message\Cog\Migration\Adapter\MySQL\Migration;
+
+class _1440409241_PageUnitRecord extends Migration
+{
+	public function up()
+	{
+		$this->run("
+			CREATE TABLE
+				product_page_unit_record
+				(
+					page_id INT(11) NOT NULL,
+					product_id INT(11) NOT NULL,
+					unit_id INT(11) DEFAULT NULL,
+					PRIMARY KEY (page_id, unit_id)
+				) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+		");
+	}
+
+	public function down()
+	{
+		$this->run("
+			DROP TABLE product_page_unit_record
+		");
+	}
+}

--- a/resources/migrations/_1440409241_PageUnitRecord.php
+++ b/resources/migrations/_1440409241_PageUnitRecord.php
@@ -12,7 +12,7 @@ class _1440409241_PageUnitRecord extends Migration
 				(
 					page_id INT(11) NOT NULL,
 					product_id INT(11) NOT NULL,
-					unit_id INT(11) DEFAULT NULL,
+					unit_id INT(11) NOT NULL,
 					PRIMARY KEY (page_id, unit_id)
 				) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 		");

--- a/resources/migrations/_1440409242_PortProductUnits.php
+++ b/resources/migrations/_1440409242_PortProductUnits.php
@@ -1,0 +1,129 @@
+<?php
+
+use Message\Cog\Migration\Adapter\MySQL\Migration;
+
+class _1440409242_PortProductUnits extends Migration
+{
+	public function up()
+	{
+		// Get units with options assigned
+		$this->run("
+			REPLACE INTO
+				product_page_unit_record
+				(
+					page_id,
+					product_id,
+					unit_id
+				)
+			SELECT DISTINCT
+					page_content.page_id,
+					product_unit.product_id,
+					product_unit.unit_id
+			FROM
+				page_content
+			JOIN
+				product_unit
+			ON
+				(
+					page_content.value_int = product_unit.product_id AND
+					page_content.group_name = 'product' AND
+					page_content.field_name = 'product'
+
+				)
+ 			LEFT JOIN
+				product_unit_option
+			USING
+				(unit_id)
+ 			JOIN
+				(
+					SELECT
+						page_id,
+						value_string AS option_value
+					FROM
+						page_content
+					WHERE
+						group_name = 'product'
+					AND
+						field_name = 'option'
+					AND
+						data_name = 'value'
+				) AS content_option_value
+			ON
+				(
+					product_unit_option.option_value = content_option_value.option_value AND
+					page_content.page_id = content_option_value.page_id
+				)
+			JOIN
+				(
+					SELECT
+						page_id,
+						value_string AS option_name
+					FROM
+						page_content
+					WHERE
+						group_name = 'product'
+					AND
+						field_name = 'option'
+					AND
+						data_name = 'name'
+				) AS content_option_name
+			ON
+				(
+					product_unit_option.option_name = content_option_name.option_name AND
+					page_content.page_id = content_option_name.page_id
+				)
+		");
+
+		// Port units without options assigned
+		$this->run("
+			REPLACE INTO
+				product_page_unit_record
+				(
+					page_id,
+					product_id,
+					unit_id
+				)
+			SELECT DISTINCT
+				page_content.page_id,
+				product_unit.product_id,
+				product_unit.unit_id
+			FROM
+				page_content
+			JOIN
+				product_unit
+			ON
+				(
+					page_content.value_int = product_unit.product_id AND
+					page_content.group_name = 'product' AND
+					page_content.field_name = 'product'
+
+				)
+			LEFT JOIN
+				(
+					SELECT
+						page_id,
+						value_string AS option_name
+					FROM
+						page_content
+					WHERE
+						group_name = 'product'
+					AND
+						field_name = 'option'
+					AND
+						data_name = 'name'
+				) AS options
+			USING
+				(page_id)
+			WHERE
+				option_name IS NULL
+			OR
+				option_name = ''
+
+		");
+	}
+
+	public function down()
+	{
+		$this->run("TRUNCATE TABLE product_page_unit_record");
+	}
+}

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -77,6 +77,10 @@ class Services implements ServicesInterface
 			return new \Message\Mothership\Ecommerce\Form\Product\ProductPagePublish;
 		});
 
+		$services['product.page.unit_record.edit'] = $services->factory(function($c) {
+			return new \Message\Mothership\Ecommerce\ProductPage\UnitRecord\Edit($c['db.transaction']);
+		});
+
 		$services['product.page.create'] = function($c) {
 			return new \Message\Mothership\Ecommerce\ProductPage\Create(
 				$c['cms.page.create'],

--- a/src/EventListener/ProductPageListener.php
+++ b/src/EventListener/ProductPageListener.php
@@ -88,7 +88,9 @@ class ProductPageListener extends BaseListener implements SubscriberInterface
 			$options = [];
 		}
 
-		$units = $this->get('product.unit.loader')->getByProduct($product);
+		$units = $this->get('product.unit.loader')
+			->includeOutOfStock()
+			->getByProduct($product);
 
 		foreach ($units as $key => $unit) {
 			foreach ($options as $name => $value) {

--- a/src/EventListener/ProductPageListener.php
+++ b/src/EventListener/ProductPageListener.php
@@ -76,7 +76,11 @@ class ProductPageListener extends BaseListener implements SubscriberInterface
 			return false;
 		}
 
-		if ($productGroup->option) {
+		if (
+			$productGroup->option &&
+			null !== $productGroup->option->getValue()['name'] ||
+			null !== $productGroup->option->getValue()['value']
+		) {
 			$options = [
 				$productGroup->option->getValue()['name'] => $productGroup->option->getValue()['value']
 			];

--- a/src/EventListener/ProductPageListener.php
+++ b/src/EventListener/ProductPageListener.php
@@ -50,6 +50,13 @@ class ProductPageListener extends BaseListener implements SubscriberInterface
 		];
 	}
 
+	/**
+	 * Load units that match up with a page based on the options that were given as content
+	 *
+	 * @param ContentEvent $event
+	 *
+	 * @return bool | void
+	 */
 	public function saveProductUnitRecords(ContentEvent $event)
 	{
 		$page = $event->getPage();

--- a/src/Filter/SaleFilter.php
+++ b/src/Filter/SaleFilter.php
@@ -53,6 +53,8 @@ class SaleFilter extends AbstractContentFilter
 
 	/**
 	 * Sets the name of the field to check for the product
+	 *
+	 * @deprecated No longer necessary since creation of `product_page_unit_record` table
 	 */
 	public function setProductField($field)
 	{
@@ -61,12 +63,14 @@ class SaleFilter extends AbstractContentFilter
 		}
 
 		$this->_productFieldName = $field;
-		
+
 		return $this;
 	}
 
 	/**
 	 * Sets the name of the field to check for the product option
+	 *
+	 * @deprecated No longer necessary since creation of `product_page_unit_record` table
 	 */
 	public function setOptionField($field)
 	{

--- a/src/ProductPage/UnitRecord/Edit.php
+++ b/src/ProductPage/UnitRecord/Edit.php
@@ -29,10 +29,6 @@ class Edit implements DB\TransactionalInterface
 			throw new \InvalidArgumentException('Units must be either an array or a Unit\\Collection instance');
 		}
 
-		if (count($units) == 0) {
-			return false;
-		}
-
 		if ($deleteExisting) {
 			$this->_transaction->add("
 				DELETE FROM
@@ -44,24 +40,25 @@ class Edit implements DB\TransactionalInterface
 			]);
 		}
 
-		$inserts = [];
-		$params = [
-			'pageID' => $page->id,
-			'productID' => $product->id,
-		];
+		if (count($units) > 0) {
+			$inserts = [];
+			$params = [
+				'pageID' => $page->id,
+				'productID' => $product->id,
+			];
 
-		foreach ($units as $unit) {
-			$inserts[] = '(' . PHP_EOL .
-					':pageID?i,' . PHP_EOL .
-					':productID?i,' . PHP_EOL .
-					':unitID' . $unit->id . '?i' . PHP_EOL .
-				')';
-			$params['unitID' . $unit->id] = $unit->id;
-		}
+			foreach ($units as $unit) {
+				$inserts[] = '(' . PHP_EOL .
+						':pageID?i,' . PHP_EOL .
+						':productID?i,' . PHP_EOL .
+						':unitID' . $unit->id . '?i' . PHP_EOL .
+					')';
+				$params['unitID' . $unit->id] = $unit->id;
+			}
 
-		$inserts = implode(',' . PHP_EOL, $inserts);
+			$inserts = implode(',' . PHP_EOL, $inserts);
 
-		$this->_transaction->add("
+			$this->_transaction->add("
 			REPLACE INTO
 				product_page_unit_record
 				(
@@ -71,6 +68,7 @@ class Edit implements DB\TransactionalInterface
 				)
 			VALUES
 		" . $inserts, $params);
+		}
 
 		$this->_commitTransaction();
 	}

--- a/src/ProductPage/UnitRecord/Edit.php
+++ b/src/ProductPage/UnitRecord/Edit.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Message\Mothership\Ecommerce\ProductPage\UnitRecord;
+
+use Message\Cog\DB;
+use Message\Mothership\CMS\Page\Page;
+use Message\Mothership\Commerce\Product\Product;
+use Message\Mothership\Commerce\Product\Unit;
+
+class Edit implements DB\TransactionalInterface
+{
+	private $_transaction;
+	private $_transOverride = false;
+
+	public function __construct(DB\Transaction $transaction)
+	{
+		$this->_transaction = $transaction;
+	}
+
+	public function setTransaction(DB\Transaction $transaction)
+	{
+		$this->_transaction = $transaction;
+		$this->_transOverride = true;
+	}
+
+	public function save(Page $page, Product $product, $units, $deleteExisting = true)
+	{
+		if (!is_array($units) && !$units instanceof Unit\Collection) {
+			throw new \InvalidArgumentException('Units must be either an array or a Unit\\Collection instance');
+		}
+
+		if (count($units) == 0) {
+			return false;
+		}
+
+		if ($deleteExisting) {
+			$this->_transaction->add("
+				DELETE FROM
+					product_page_unit_record
+				WHERE
+					page_id = :pageID?i
+			", [
+				'pageID' => $page->id,
+			]);
+		}
+
+		$inserts = [];
+		$params = [
+			'pageID' => $page->id,
+			'productID' => $product->id,
+		];
+
+		foreach ($units as $unit) {
+			$inserts[] = '(' . PHP_EOL .
+					':pageID?i,' . PHP_EOL .
+					':productID?i,' . PHP_EOL .
+					':unitID' . $unit->id . '?i' . PHP_EOL .
+				')';
+			$params['unitID' . $unit->id] = $unit->id;
+		}
+
+		$inserts = implode(',' . PHP_EOL, $inserts);
+
+		$this->_transaction->add("
+			REPLACE INTO
+				product_page_unit_record
+				(
+					page_id,
+					product_id,
+					unit_id
+				)
+			VALUES
+		" . $inserts, $params);
+
+		$this->_commitTransaction();
+	}
+
+	private function _commitTransaction()
+	{
+		if (false === $this->_transOverride) {
+			$this->_transaction->commit();
+		}
+	}
+}

--- a/src/ProductPage/UnitRecord/Edit.php
+++ b/src/ProductPage/UnitRecord/Edit.php
@@ -7,22 +7,52 @@ use Message\Mothership\CMS\Page\Page;
 use Message\Mothership\Commerce\Product\Product;
 use Message\Mothership\Commerce\Product\Unit;
 
+/**
+ * Class Edit
+ * @package Message\Mothership\Ecommerce\ProductPage\UnitRecord
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Class for saving unit and product IDs for a product page for quick access in database queries
+ */
 class Edit implements DB\TransactionalInterface
 {
+	/**
+	 * @var DB\Transaction
+	 */
 	private $_transaction;
+
+	/**
+	 * @var bool
+	 */
 	private $_transOverride = false;
 
+	/**
+	 * @param DB\Transaction $transaction
+	 */
 	public function __construct(DB\Transaction $transaction)
 	{
 		$this->_transaction = $transaction;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public function setTransaction(DB\Transaction $transaction)
 	{
 		$this->_transaction = $transaction;
 		$this->_transOverride = true;
 	}
 
+	/**
+	 * Loop through unit IDs and save them with the page ID and product ID
+	 *
+	 * @param Page $page                         The product page being edited
+	 * @param Product $product                   The product assigned to the page
+	 * @param array | Unit\Collection $units     The units that fit the requirements of the page
+	 * @param bool $deleteExisting               Determines whether existing rows should be deleted before
+	 *                                           save, defaults to true
+	 */
 	public function save(Page $page, Product $product, $units, $deleteExisting = true)
 	{
 		if (!is_array($units) && !$units instanceof Unit\Collection) {
@@ -59,20 +89,23 @@ class Edit implements DB\TransactionalInterface
 			$inserts = implode(',' . PHP_EOL, $inserts);
 
 			$this->_transaction->add("
-			REPLACE INTO
-				product_page_unit_record
-				(
-					page_id,
-					product_id,
-					unit_id
-				)
-			VALUES
+				REPLACE INTO
+					product_page_unit_record
+					(
+						page_id,
+						product_id,
+						unit_id
+					)
+				VALUES
 		" . $inserts, $params);
 		}
 
 		$this->_commitTransaction();
 	}
 
+	/**
+	 * Commit database transaction if not overridden
+	 */
 	private function _commitTransaction()
 	{
 		if (false === $this->_transOverride) {


### PR DESCRIPTION
This PR creates a table for keeping track of which units apply to which pages. Since product pages set options, which could apply to multiple units, it was difficult to create efficient queries in the page filters, meaning that if a website had thousands of products, it would grind to a halt. This table makes picking out those units a lot simpler as it doesn't require loads of crazy logical joins