### PR TITLE
Check product option field exists on product page listener

### DIFF
--- a/src/EventListener/ProductPageListener.php
+++ b/src/EventListener/ProductPageListener.php
@@ -83,12 +83,13 @@ class ProductPageListener extends BaseListener implements SubscriberInterface
 			return false;
 		}
 
-		$optionFieldExists = array_key_exists('option', $productGroup->getFields());
-
 		if (
-			$optionFieldExists &&
-			($productGroup->option &&
-			null !== $productGroup->option->getValue()['name'] ||
+			// Check field exists
+			isset($productGroup->option) &&
+			// Check field has a value
+			$productGroup->option->getValue() &&
+			// Check at least one value is set
+			(null !== $productGroup->option->getValue()['name'] ||
 			null !== $productGroup->option->getValue()['value'])
 		) {
 			$options = [

--- a/src/EventListener/ProductPageListener.php
+++ b/src/EventListener/ProductPageListener.php
@@ -83,10 +83,13 @@ class ProductPageListener extends BaseListener implements SubscriberInterface
 			return false;
 		}
 
+		$optionFieldExists = array_key_exists('option', $productGroup->getFields());
+
 		if (
-			$productGroup->option &&
+			$optionFieldExists &&
+			($productGroup->option &&
 			null !== $productGroup->option->getValue()['name'] ||
-			null !== $productGroup->option->getValue()['value']
+			null !== $productGroup->option->getValue()['value'])
 		) {
 			$options = [
 				$productGroup->option->getValue()['name'] => $productGroup->option->getValue()['value']


### PR DESCRIPTION
This PR fixes the issue where the `ProductPageListener` would break on pages that do not have a product option field.

This was breaking because the `$productGroup->option` check calls a magic getting on `Field\Group` which throws an exception because that field does not exist, and so it was impossible to save product pages