### PR TITLE
Allow instances of PageType to be passed to ProductPage creation

### DIFF
--- a/resources/view/product/page-list.html.twig
+++ b/resources/view/product/page-list.html.twig
@@ -25,11 +25,14 @@
 							</a>
 						</td>
 						<td>
-							{{ page.content.product.option.name }}
+							{% if not page.content.option.value is empty %}
+								{{ page.content.product.option.name }}
+							{% endif %}
 						</td>
 						<td>
-
-							{{ page.content.product.option.value }}
+							{% if not page.content.option.value is empty %}
+								{{ page.content.product.option.value }}
+							{% endif %}
 						</td>
 					</tr>
 				{% endfor %}

--- a/resources/view/product/page-list.html.twig
+++ b/resources/view/product/page-list.html.twig
@@ -28,6 +28,7 @@
 							{{ page.content.product.option.name }}
 						</td>
 						<td>
+
 							{{ page.content.product.option.value }}
 						</td>
 					</tr>

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -144,6 +144,28 @@ class Services implements ServicesInterface
 		$services['product.page.brand_validator'] = function($c) {
 			return new \Message\Mothership\Ecommerce\ProductPage\UploadData\BrandValidator($c['product.upload.heading_keys']);
 		};
+
+		// Override from commerce to allow the use of page mappings.
+		$services['product.page_mapper.simple'] = function($c) {
+			$mapper = new \Message\Mothership\Commerce\ProductPageMapper\SimpleMapper(
+				$c['db.query'],
+				$c['cms.page.loader'],
+				$c['cms.page.authorisation'],
+				$c['product.loader'],
+				$c['product.unit.loader']
+			);
+
+			$mapper->setValidFieldNames('product');
+			$mapper->setValidGroupNames(null);
+			$mapper->setValidPageTypes(
+				array_merge(
+					['product'],
+					array_values($c['product.page_type.mapping'])
+				)
+			);
+
+			return $mapper;
+		};
 	}
 
 	public function addOrderStatuses($services)

--- a/src/ProductPage/Create.php
+++ b/src/ProductPage/Create.php
@@ -117,7 +117,7 @@ class Create
 		array $productPageTypeMapping
 	)
 	{
-		if ($listingPageType !== null && $listingPageType instanceof PageType\PageTypeInterface) {
+		if ($listingPageType !== null && !$listingPageType instanceof PageType\PageTypeInterface) {
 			throw new \InvalidArgumentException('Variable $listingPageType must be instance of PageType\PageTypeInterface or null');
 		}
 


### PR DESCRIPTION
This if statement was not allowing the Create service to be called with PageTypes.

Test on product upload page creation as well as the product page listing.

This also adds a page mapper service to e-commerce which takes into account the page page mapping array.