### PR TITLE
Check other option possibilities for option values

### DIFF
--- a/resources/view/product/page-list.html.twig
+++ b/resources/view/product/page-list.html.twig
@@ -25,13 +25,17 @@
 							</a>
 						</td>
 						<td>
-							{% if not page.content.option.value is empty %}
+							{% if not page.content.product.option.value is empty %}
 								{{ page.content.product.option.name }}
+							{% elseif not page.content.product.productoption.value is empty %}
+								{{ page.content.product.productoption.name }}
 							{% endif %}
 						</td>
 						<td>
-							{% if not page.content.option.value is empty %}
+							{% if not page.content.product.option.value is empty %}
 								{{ page.content.product.option.value }}
+							{% elseif not page.content.product.productoption.value is empty %}
+								{{ page.content.product.productoption.value }}
 							{% endif %}
 						</td>
 					</tr>


### PR DESCRIPTION
The product page listing wasn't looking at the correct field. It was also not taking possible "productoption" fields into account.

Test the listing shows options and values on sites using "productoption" as well as stes using "option" as names for the product option.