### PR TITLE
Fire events during checkout

### DIFF
--- a/src/Checkout/Event.php
+++ b/src/Checkout/Event.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Message\Mothership\Ecommerce\Checkout;
+
+use Message\Cog\Event\Event as BaseEvent;
+use Message\Mothership\Commerce\Order\Order;
+
+/**
+ * Class Event
+ * @package Message\Mothership\Ecommerce\Checkout
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Event to be fired at various stages throughout checkout. This allows event listeners in Mothership
+ * installations to make additional alterations to the order going through checkout.
+ */
+class Event extends BaseEvent
+{
+	/**
+	 * @var Order
+	 */
+	private $_order;
+
+	/**
+	 * @var array
+	 */
+	private $_data;
+
+	/**
+	 * @param Order $order
+	 * @param array $data
+	 */
+	public function __construct(Order $order, array $data = [])
+	{
+		$this->setOrder($order);
+		$this->setData($data);
+	}
+
+	/**
+	 * @param Order $order
+	 */
+	public function setOrder(Order $order)
+	{
+		$this->_order = $order;
+	}
+
+	/**
+	 * @return Order
+	 */
+	public function getOrder()
+	{
+		return $this->_order;
+	}
+
+	/**
+	 * @param array $data
+	 */
+	public function setData(array $data)
+	{
+		$this->_data = $data;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getData()
+	{
+		return $this->_data;
+	}
+}

--- a/src/Checkout/Events.php
+++ b/src/Checkout/Events.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Message\Mothership\Ecommerce\Checkout;
+
+/**
+ * Class Events
+ * @package Message\Mothership\Ecommerce\Checkout
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Class of constants for identifying events dispatched during checkout
+ */
+class Events
+{
+	// Fired at initial stage of checkout if any units are changed
+	const REVIEW = 'ecom.checkout.review';
+
+	// Fired after the user has submitted their address details
+	const ADDRESSES = 'ecom.checkout.address';
+
+	// Fired before the payment stages after the user has submitted any notes and confirmed their order is correct
+	const CONFIRM = 'ecom.checkout.confirm';
+}

--- a/src/Controller/Checkout/Checkout.php
+++ b/src/Controller/Checkout/Checkout.php
@@ -3,6 +3,8 @@
 namespace Message\Mothership\Ecommerce\Controller\Checkout;
 
 use Message\Cog\Controller\Controller;
+use Message\Mothership\Ecommerce\Checkout\Event as CheckoutEvent;
+use Message\Mothership\Ecommerce\Checkout\Events as CheckoutEvents;
 
 /**
  * Class Checkout
@@ -27,6 +29,11 @@ class Checkout extends Controller
 				$unit = $product->getUnit($unitID);
 				$basket->updateQuantity($unit, $quantity);
 			}
+
+			$this->get('event.dispatcher')->dispatch(
+				CheckoutEvents::REVIEW,
+				new CheckoutEvent($this->get('basket')->getOrder(), $data)
+			);
 
 			$this->addFlash('success','Basket updated');
 		}

--- a/src/Controller/Checkout/Complete.php
+++ b/src/Controller/Checkout/Complete.php
@@ -84,9 +84,11 @@ class Complete extends Controller implements CompleteControllerInterface
 	/**
 	 * Show the confirmation page for a successful order.
 	 *
-	 * @param  int 		$orderID 	confirmed orderID to laod and display
-	 * @param  string 	$hash   	hash to ensure we only display the order page to good people
-	 * @return View 				order confirmation page
+	 * @param int $orderID                     Confirmed orderID to laod and display
+	 * @param string $hash                     Hash to ensure we only display the order page to good people
+	 * @throws \Exception
+	 *
+	 * @return \Message\Cog\HTTP\Response      Order confirmation page
 	 */
 	public function successful($orderID, $hash)
 	{

--- a/src/Controller/Checkout/Confirm.php
+++ b/src/Controller/Checkout/Confirm.php
@@ -2,11 +2,12 @@
 
 namespace Message\Mothership\Ecommerce\Controller\Checkout;
 
-use Message\Mothership\Commerce\Order\Entity\Note\Note;
 use Message\Cog\Controller\Controller;
 use Message\Cog\Form\Handler as DeprecatedForm;
 use Message\Mothership\Commerce\Address\Address;
+use Message\Mothership\Commerce\Order\Entity\Note\Note;
 use Message\Mothership\Ecommerce\Gateway\GatewayInterface;
+use Message\Mothership\Ecommerce\Checkout;
 use Symfony\Component\Form\Form as SymfonyForm;
 
 /**
@@ -280,6 +281,11 @@ class Confirm extends Controller
 
 		// Forward the request to the gateway purchase reference
 		$controller = 'Message:Mothership:Ecommerce::Controller:Checkout:Complete';
+
+		$this->get('event.dispatcher')->dispatch(
+			Checkout\Events::CONFIRM,
+			new Checkout\Event($this->get('basket')->getOrder(), $data)
+		);
 
 		return $this->forward($gateway->getPurchaseControllerReference(), [
 			'payable' => $this->get('basket')->getOrder(),

--- a/src/Controller/Checkout/Details.php
+++ b/src/Controller/Checkout/Details.php
@@ -2,11 +2,9 @@
 
 namespace Message\Mothership\Ecommerce\Controller\Checkout;
 
-use Message\Mothership\Ecommerce\Form\UserDetails;
 use Message\Cog\Controller\Controller;
-use Message\User\User;
-use Message\User\AnonymousUser;
 use Message\Mothership\User\Address\Address;
+use Message\Mothership\Ecommerce\Checkout;
 
 /**
  * Checkout Details - amend order addresses
@@ -117,6 +115,11 @@ class Details extends Controller
 			}
 
 			$this->get('basket')->setEntities('addresses', $addresses);
+
+			$this->get('event.dispatcher')->dispatch(
+				Checkout\Events::ADDRESSES,
+				new Checkout\Event($this->get('basket')->getOrder(), $data)
+			);
 
 			return $this->redirectToRoute('ms.ecom.checkout.confirm');
 		}

--- a/tests/Checkout/EventTest.php
+++ b/tests/Checkout/EventTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Message\Mothership\Ecommerce\Test\Checkout;
+
+use Message\Mothership\Ecommerce\Checkout\Event;
+
+class EventTest extends \PHPUnit_Framework_TestCase
+{
+	public function testGetOrder()
+	{
+		$order = $this->_getOrder();
+		$event = new Event($order);
+
+		$this->assertSame($order, $event->getOrder());
+	}
+
+	public function testGetData()
+	{
+		$data = ['hello' => 'world'];
+		$event = new Event($this->_getOrder(), $data);
+
+		$this->assertSame($data, $event->getData());
+	}
+
+	public function testGetDataEmpty()
+	{
+		$event = new Event($this->_getOrder());
+
+		$this->assertSame([], $event->getData());
+	}
+
+	public function testSetOrder()
+	{
+		$event = new Event($this->_getOrder());
+		$order = $this->_getOrder();
+		$order->id = 1;
+		$event->setOrder($order);
+
+		$this->assertSame($order, $event->getOrder());
+	}
+
+	public function testSetData()
+	{
+		$event = new Event($this->_getOrder(), ['hello' =>  'world']);
+		$data = ['goodbye' => 'moon'];
+		$event->setData($data);
+
+		$this->assertSame($data, $event->getData());
+	}
+
+	public function testSetDataFromEmpty()
+	{
+		$event = new Event($this->_getOrder());
+		$data = ['goodbye' => 'moon'];
+		$event->setData($data);
+
+		$this->assertSame($data, $event->getData());
+	}
+
+	private function _getOrder()
+	{
+		return $this->getMockBuilder('Message\\Mothership\\Commerce\\Order\\Order')
+			->disableOriginalConstructor()
+			->getMock()
+		;
+	}
+}


### PR DESCRIPTION
This PR adds new event classes to be fired during checkout. The events carry the order instance as well as any form data that had been submitted. 

An event is fired if the user alters their basket in the first stage of checkout, after the user has submitted/confirmed their address, and just before the payment stage.