### PR TITLE
Feature/addresses logout redirect

### DIFF
--- a/src/Controller/Checkout/Details.php
+++ b/src/Controller/Checkout/Details.php
@@ -3,6 +3,7 @@
 namespace Message\Mothership\Ecommerce\Controller\Checkout;
 
 use Message\Cog\Controller\Controller;
+use Message\User\AnonymousUser;
 use Message\Mothership\User\Address\Address;
 use Message\Mothership\Ecommerce\Checkout;
 
@@ -79,6 +80,10 @@ class Details extends Controller
 	 */
 	public function addresses()
 	{
+		if (!$this->get('user.current') || $this->get('user.current') instanceof AnonymousUser) {
+			return $this->redirectToRoute('ms.ecom.checkout.details');
+		}
+
 		$form = $this->createForm($this->get('checkout.form.addresses'));
 
 		$form->handleRequest();

--- a/src/Controller/Checkout/Details.php
+++ b/src/Controller/Checkout/Details.php
@@ -81,7 +81,7 @@ class Details extends Controller
 	public function addresses()
 	{
 		if (!$this->get('user.current') || $this->get('user.current') instanceof AnonymousUser) {
-			return $this->redirectToRoute('ms.ecom.checkout.details');
+			return $this->redirectToRoute('ms.ecom.checkout');
 		}
 
 		$form = $this->createForm($this->get('checkout.form.addresses'));


### PR DESCRIPTION
If users logged out during the addresses stage of checkout it wouldn't redirect, causing an error when attempting to render the form. To test, log out during the address stage of checkout, it should redirect you to the start