### PR TITLE
Cancel refund event listener

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -274,6 +274,7 @@ class Services implements ServicesInterface
 		});
 
 		// Active gateway service
+		// @deprecated call `gateways` instead and select the appropriate gateway
 		$services['gateway'] = function($c) {
 			$gateway = $c['cfg']->payment->gateway;
 

--- a/src/EventListener/OrderListener.php
+++ b/src/EventListener/OrderListener.php
@@ -36,6 +36,9 @@ class OrderListener extends BaseListener implements SubscriberInterface
 		);
 	}
 
+	/**
+	 * @param Order\Event\Event $event
+	 */
 	public function sendOrderConfirmationMail(Order\Event\Event $event)
 	{
 		$order = $event->getOrder();
@@ -52,6 +55,9 @@ class OrderListener extends BaseListener implements SubscriberInterface
 		}
 	}
 
+	/**
+	 * @param Order\Event\UpdateFailedEvent $event
+	 */
 	public function redirectToHome(Order\Event\UpdateFailedEvent $event)
 	{
 		$page = $this->get('cms.page.loader')->getHomepage();
@@ -62,16 +68,29 @@ class OrderListener extends BaseListener implements SubscriberInterface
 		$this->get('event.dispatcher')->dispatch(Page\Event\Event::RENDER_SET_RESPONSE, $redirectEvent);
 	}
 
+	/**
+	 * @param Order\Event\CancelEvent $event
+	 */
 	public function setOrderRefundController(Order\Event\CancelEvent $event)
 	{
 		$this->_setRefundController($event, 'order');
 	}
 
+	/**
+	 * @param Order\Event\CancelEvent $event
+	 */
 	public function setItemRefundController(Order\Event\CancelEvent $event)
 	{
 		$this->_setRefundController($event, 'item');
 	}
 
+	/**
+	 * Set controller and parameters to process refund via gateway. Can configure cancellation for
+	 * orders or individual items by giving 'order' or 'item' as the second parameter
+	 *
+	 * @param Order\Event\CancelEvent $event
+	 * @param $type
+	 */
 	private function _setRefundController(Order\Event\CancelEvent $event, $type)
 	{
 		$types = ['order', 'item'];
@@ -92,7 +111,7 @@ class OrderListener extends BaseListener implements SubscriberInterface
 
 		$event->setControllerReference($gateway->getRefundControllerReference());
 		$event->setParams([
-			'payable' => $event->getPayable(),
+			'payable' => $event->getRefund(),
 			'reference' => $paymentReference,
 			'stages' => [
 				'failure' => $controller . '#' . $type . 'Failure',


### PR DESCRIPTION
Requires https://github.com/mothership-ec/cog-mothership-commerce/pull/490

This PR adds an event listener which tells Commerce how to process a refund if an order is cancelled. This helps to move some of the logic back to E-commerce where the gateways exist, rather than leaving it in Commerce and just hoping that the E-commerce module is installed.