### PR TITLE
Use default gateway when creating orders if not set on session

### DIFF
--- a/src/Controller/Checkout/Complete.php
+++ b/src/Controller/Checkout/Complete.php
@@ -51,6 +51,14 @@ class Complete extends Controller implements CompleteControllerInterface
 
 		// Save gateway against payment
 		$gateway = $this->get('http.session')->get('gateway.current');
+
+		// If gateway is not set on session, get default gateway
+		if (null !== $gateway) {
+			$gatewayNames = $this->get('cfg')->payment->gateway;
+			$gatewayName = is_array($gatewayNames) ? array_shift($gatewayNames) : $gatewayNames;
+			$gateway = $this->get('gateway.collection')->get($gatewayName);
+		}
+
 		$this->get('payment.gateway.edit')->save($payment, $gateway);
 
 		// Create json response with the success url

--- a/src/Controller/Checkout/Complete.php
+++ b/src/Controller/Checkout/Complete.php
@@ -53,7 +53,7 @@ class Complete extends Controller implements CompleteControllerInterface
 		$gateway = $this->get('http.session')->get('gateway.current');
 
 		// If gateway is not set on session, get default gateway
-		if (null !== $gateway) {
+		if (null === $gateway) {
 			$gatewayNames = $this->get('cfg')->payment->gateway;
 			$gatewayName = is_array($gatewayNames) ? array_shift($gatewayNames) : $gatewayNames;
 			$gateway = $this->get('gateway.collection')->get($gatewayName);


### PR DESCRIPTION
When paying with SagePay, the order is temporarily stored in the cache as the session is not available at the point of order creation. This means that the gateway is *not* on the session. In this instance, it will default to the primary gateway, rather than passing `NULL` to the `payment.gateway.edit` class, which threw an error.

See https://github.com/mothership-ec/cog-mothership-ecommerce/issues/268