### PR TITLE
Replace missing address form

### DIFF
--- a/resources/view/fulfillment/process/address.html.twig
+++ b/resources/view/fulfillment/process/address.html.twig
@@ -3,11 +3,9 @@
 {% block process %}
 	<h2>Amending address for dispatch {{ dispatch.id }} for order {{ dispatch.order.id }}</h2>
 	<section class="group">
-
-	</section>
-
 	{{ form_start(form) }}
 		<button type="submit" class="button small save" id="save-content">Update</button>
 	{{form_end(form)  }}
+	</section>
 
 {% endblock %}

--- a/src/Controller/Fulfillment/Process.php
+++ b/src/Controller/Fulfillment/Process.php
@@ -335,28 +335,6 @@ class Process extends Controller
 		}
 
 		$newAddress = $form->getData();
-//
-//		$newAddress = new Order\Entity\Address\Address;
-//
-//		$newAddress->order = $address->order;
-//		$newAddress->type  = $address->type;
-//
-//		for ($i = 1; $i <= $newAddress::AMOUNT_LINES; $i++) {
-//			$newAddress->lines[$i] = $data['address_line_' . $i];
-//		}
-//
-//		$newAddress->title     = $data['title'];
-//		$newAddress->forename  = $data['forename'];
-//		$newAddress->surname   = $data['surname'];
-//		$newAddress->town      = $data['town'];
-//		$newAddress->postcode  = $data['postcode'];
-//		$newAddress->telephone = $data['telephone'];
-//		if ($data['state_id']) {
-//			$newAddress->state   = $this->get('state.list')->getByID($data['country_id'], $data['state_id']);
-//			$newAddress->stateID = $data['state_id'];
-//		}
-//		$newAddress->country   = $this->get('country.list')->getByID($data['country_id']);
-//		$newAddress->countryID = $data['country_id'];
 
 		$this->get('order.address.create')->create($newAddress);
 

--- a/src/Controller/Fulfillment/Process.php
+++ b/src/Controller/Fulfillment/Process.php
@@ -324,8 +324,9 @@ class Process extends Controller
 		$address = $this->get('order.address.loader')->getByID($addressID);
 
 		$form = $this->_getAddressForm($dispatch, $address);
+		$form->handleRequest();
 
-		if (! $form->isValid() or false === $data = $form->getFilteredData()) {
+		if (!$form->isValid()) {
 			return $this->redirectToRoute('ms.ecom.fulfillment.process.address', array(
 				'orderID'    => $orderID,
 				'dispatchID' => $dispatchID,
@@ -333,27 +334,29 @@ class Process extends Controller
 			));
 		}
 
-		$newAddress = new Order\Entity\Address\Address;
-
-		$newAddress->order = $address->order;
-		$newAddress->type  = $address->type;
-
-		for ($i = 1; $i <= $newAddress::AMOUNT_LINES; $i++) {
-			$newAddress->lines[$i] = $data['address_line_' . $i];
-		}
-
-		$newAddress->title     = $data['title'];
-		$newAddress->forename  = $data['forename'];
-		$newAddress->surname   = $data['surname'];
-		$newAddress->town      = $data['town'];
-		$newAddress->postcode  = $data['postcode'];
-		$newAddress->telephone = $data['telephone'];
-		if ($data['state_id']) {
-			$newAddress->state   = $this->get('state.list')->getByID($data['country_id'], $data['state_id']);
-			$newAddress->stateID = $data['state_id'];
-		}
-		$newAddress->country   = $this->get('country.list')->getByID($data['country_id']);
-		$newAddress->countryID = $data['country_id'];
+		$newAddress = $form->getData();
+//
+//		$newAddress = new Order\Entity\Address\Address;
+//
+//		$newAddress->order = $address->order;
+//		$newAddress->type  = $address->type;
+//
+//		for ($i = 1; $i <= $newAddress::AMOUNT_LINES; $i++) {
+//			$newAddress->lines[$i] = $data['address_line_' . $i];
+//		}
+//
+//		$newAddress->title     = $data['title'];
+//		$newAddress->forename  = $data['forename'];
+//		$newAddress->surname   = $data['surname'];
+//		$newAddress->town      = $data['town'];
+//		$newAddress->postcode  = $data['postcode'];
+//		$newAddress->telephone = $data['telephone'];
+//		if ($data['state_id']) {
+//			$newAddress->state   = $this->get('state.list')->getByID($data['country_id'], $data['state_id']);
+//			$newAddress->stateID = $data['state_id'];
+//		}
+//		$newAddress->country   = $this->get('country.list')->getByID($data['country_id']);
+//		$newAddress->countryID = $data['country_id'];
 
 		$this->get('order.address.create')->create($newAddress);
 
@@ -581,12 +584,14 @@ class Process extends Controller
 
 	protected function _getAddressForm($dispatch, $address)
 	{
-		$form = new Form\UserDetails($this->_services);
-		$form->buildForm($dispatch->order->user, $address, 'delivery', $this->generateUrl('ms.ecom.fulfillment.process.address', array(
-			'orderID'    => $dispatch->order->id,
-			'dispatchID' => $dispatch->id,
-			'addressID'  => $address->id,
-		)));
+		$form = $this->createForm($this->get('address.form'), $address, [
+			'address_type' => 'delivery',
+			'action' => $this->generateUrl('ms.ecom.fulfillment.process.address', [
+				'orderID'    => $dispatch->order->id,
+				'dispatchID' => $dispatch->id,
+				'addressID'  => $address->id,
+			])
+		]);
 
 		return $form;
 	}

--- a/src/Form/AddressForm.php
+++ b/src/Form/AddressForm.php
@@ -8,7 +8,6 @@ use Symfony\Component\Validator\Constraints;
 
 class AddressForm extends Form\AbstractType
 {
-
 	protected $_services;
 
 	public function __construct($services)


### PR DESCRIPTION
I'm not sure what happened but for some reason the form that handles editing addresses in the `Post` stage of fulfilment had been deleted. The form already existed so I included just replaced it and it seems to be working