### PR TITLE
Fix typos on gateway exceptions

### DIFF
--- a/src/Payment/GatewayNotFoundException.php
+++ b/src/Payment/GatewayNotFoundException.php
@@ -7,5 +7,5 @@ namespace Message\Mothership\Ecommerce\Payment;
  *
  * Exception thrown if no gateway record is found
  */
-class GatewayNotFoundException extends \LogicExceptiion
+class GatewayNotFoundException extends \LogicException
 {}

--- a/src/Payment/PaymentGatewayRecordLoader.php
+++ b/src/Payment/PaymentGatewayRecordLoader.php
@@ -56,7 +56,7 @@ class PaymentGatewayRecordLoader
 			->run();
 
 		if (!$result->count() || !$result->value()) {
-			throw new \GatewayNotFoundException("No record found for the given payment.");
+			throw new GatewayNotFoundException("No record found for the given payment.");
 		}
 
 		$result = $result->value();


### PR DESCRIPTION
These typos when throwing exceptions in the payment section were causing fatal errors instead of catchable exceptions